### PR TITLE
create::array() from const range, e.g. views

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,7 +1,7 @@
 # Multiple platforms and compilers
 name: build and test
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   build:
@@ -9,18 +9,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Cannot use ubuntu-latest with clang due to github bug: https://github.com/actions/runner-images/discussions/9446
-        os: [ubuntu-20.04, ubuntu-latest, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
         build_type: [Debug, Release]
         c_compiler: [gcc, clang, cl]
         include:
           - os: windows-latest
             c_compiler: cl
             cpp_compiler: cl
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             c_compiler: gcc
             cpp_compiler: g++
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             c_compiler: clang
             cpp_compiler: clang++
         exclude:
@@ -28,14 +27,8 @@ jobs:
             c_compiler: gcc
           - os: windows-latest
             c_compiler: clang
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             c_compiler: cl
-          - os: ubuntu-latest
-            c_compiler: clang
-          - os: ubuntu-20.04
-            c_compiler: cl
-          - os: ubuntu-20.04
-            c_compiler: gcc
 
     steps:
     - uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,8 @@ cmake_minimum_required(VERSION 3.20)
 
 project(decodeless_allocator)
 
-set(CMAKE_CXX_STANDARD 20)
-
 add_library(decodeless_allocator INTERFACE)
+target_compile_features(decodeless_allocator INTERFACE cxx_std_20)
 target_include_directories(decodeless_allocator INTERFACE include)
 
 # cmake namespace style alias

--- a/include/decodeless/allocator_construction.hpp
+++ b/include/decodeless/allocator_construction.hpp
@@ -55,7 +55,7 @@ std::span<T> array(MemoryResource& memoryResource, Range&& range) {
     auto result = std::span(
         reinterpret_cast<T*>(memoryResource.allocate(sizeof(T) * size, alignof(T))), size);
     auto out = result.begin();
-    for (auto& in : range)
+    for (const auto& in : range)
         std::construct_at<T>(&*out++, in);
     return result;
 };
@@ -112,7 +112,7 @@ std::span<T> array(const Allocator& allocator, Range&& range) {
     auto size = std::ranges::size(range);
     auto result = std::span(allocator_rebind_t<T, Allocator>(allocator).allocate(size), size);
     auto out = result.begin();
-    for (auto& in : range)
+    for (const auto& in : range)
         std::construct_at<T>(&*out++, in);
     return result;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,17 +27,27 @@ if(MSVC)
   target_compile_options(${PROJECT_NAME}_tests PRIVATE /W4 /WX)
   target_compile_definitions(${PROJECT_NAME}_tests PRIVATE WIN32_LEAN_AND_MEAN=1 NOMINMAX)
 else()
-  target_compile_options(${PROJECT_NAME}_tests PRIVATE -Wall -Wextra -Wpedantic -Werror)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(${PROJECT_NAME}_tests PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Werror
+    -ftemplate-backtrace-limit=0
+    # Note: some of these are ABI breaking and are only safe here due to
+    # all dependencies being header-only
+    # https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html
+    $<$<CONFIG:Debug>:-D_GLIBCXX_ASSERTIONS>
+    $<$<CONFIG:Debug>:-D_GLIBCXX_DEBUG>
+    $<$<CONFIG:Debug>:-D_GLIBCXX_DEBUG_PEDANTIC>
+    $<$<CONFIG:Debug>:-D_GLIBCXX_CONCEPT_CHECKS>
+    $<$<CONFIG:Debug>:-D_GLIBCXX_SANITIZE_VECTOR>
+    )
+  option(DECODELESS_TESTING_ENABLE_ASAN "Compile decodeless tests with sanitizers" ON)
+  if(DECODELESS_TESTING_ENABLE_ASAN)
     target_compile_options(${PROJECT_NAME}_tests PRIVATE
-      $<$<CONFIG:Debug>:-D_GLIBCXX_DEBUG>
-      $<$<CONFIG:Debug>:-D_GLIBCXX_DEBUG_BACKTRACE>)
-    try_compile(HAS_STDCXX_LIBBACKTRACE
-      SOURCE_FROM_CONTENT stdc++_libbacktrace_test.cpp "int main() { return 0; }"
-      LINK_LIBRARIES stdc++_libbacktrace)
-    if(HAS_STDCXX_LIBBACKTRACE)
-      target_link_libraries(${PROJECT_NAME}_tests $<$<CONFIG:Debug>:stdc++_libbacktrace>)
-    endif()
+      $<$<CONFIG:Debug>:-fsanitize=address,undefined,leak>)
+    target_link_options(${PROJECT_NAME}_tests PRIVATE
+      $<$<CONFIG:Debug>:-fsanitize=address,undefined,leak>)
   endif()
 endif()
 

--- a/test/src/allocator.cpp
+++ b/test/src/allocator.cpp
@@ -8,8 +8,10 @@
 #include <decodeless/allocator.hpp>
 #include <decodeless/allocator_construction.hpp>
 #include <decodeless/pmr_allocator.hpp>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <initializer_list>
+#include <utility>
 
 using namespace decodeless;
 
@@ -234,6 +236,15 @@ TEST(Allocate, PmrVectorRelaxed) {
     vec.reserve(20);
     EXPECT_GT(res.size(), allocated);
     EXPECT_THROW(vec.reserve(100), std::bad_alloc);
+}
+
+TEST(Allocate, ArrayFromView) {
+    using namespace std::views;
+    auto                   running_sum = [l = 0](int i) mutable { return std::exchange(l, l + i); };
+    std::vector            ints{1, 2, 3, 4, 5};
+    linear_memory_resource alloc(100);
+    std::span<int> array = decodeless::create::array(alloc, ints | transform(running_sum));
+    EXPECT_THAT(array, testing::ElementsAre(0, 1, 3, 6, 10));
 }
 
 TEST(Allocate, Readme) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new test case for creating an array from a view, validating the allocator's functionality with transformed views.
	- Added an option to enable AddressSanitizer for improved debugging during testing.
	- Updated CI/CD workflow to use a more recent version of Ubuntu for enhanced compatibility.

- **Bug Fixes**
	- Enhanced safety by ensuring elements in the range are not modified during iteration in key functions.

- **Chores**
	- Updated the CMake configuration to improve modularity, targeting specific libraries for C++20 features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->