### PR TITLE
Fix compilation on Visual Studio 2019 v16.11.42

### DIFF
--- a/include/decodeless/allocator.hpp
+++ b/include/decodeless/allocator.hpp
@@ -55,6 +55,11 @@ public:
     using parent_allocator = ResOrAlloc;
 
     // Non-reallocating parent allocator constructor must take an initial size
+#if _MSC_VER < 1930
+    // MSVC 2019 doesn't allow a trailing requires clause on a function of a
+    // templated class. Adding a dummy template like this avoids error C7599.
+    template<class U = ResOrAlloc>
+#endif
     linear_memory_resource(size_t initialSize, const ResOrAlloc& parent = ResOrAlloc())
         requires allocator<ResOrAlloc>
         : m_parent(parent)
@@ -68,6 +73,9 @@ public:
 
     // Non-reallocating parent memory_resource constructor must take an initial
     // size
+#if _MSC_VER < 1930
+    template<class U = ResOrAlloc>
+#endif
     linear_memory_resource(size_t initialSize, ResOrAlloc&& parent)
         requires memory_resource<ResOrAlloc>
         : m_parent(std::move(parent))
@@ -80,17 +88,26 @@ public:
     }
 
     // Reallocating parent allocator may default construct
+#if _MSC_VER < 1930
+    template<class U = ResOrAlloc>
+#endif
     linear_memory_resource()
         requires realloc_allocator<ResOrAlloc>
-    = default;
+        : m_parent() {}
 
     // Reallocating parent allocator can be copied
+#if _MSC_VER < 1930
+    template<class U = ResOrAlloc>
+#endif
     linear_memory_resource(const ResOrAlloc& parent)
         requires realloc_allocator<ResOrAlloc>
         : m_parent(parent) {}
 
     // Reallocating parent memory_resource must be moved into the linear
     // resource
+#if _MSC_VER < 1930
+    template<class U = ResOrAlloc>
+#endif
     linear_memory_resource(ResOrAlloc&& parent)
         requires realloc_memory_resource<ResOrAlloc>
         : m_parent(std::move(parent)) {}


### PR DESCRIPTION
Although Visual Studio 2022 allows function members in a templated class to use `requires` (and this appears to be permitted by the language, although I haven't dug deeper than CPPReference here), Visual Studio 2019 emits Error C7599, "a trailing requires clause is only allowed on a templated function" when attempting to compile members of `linear_memory_resource`.

My solution is to make these functions templated as well, with a default template argument equal to the class' template argument. Since templated constructors can't be defaulted, I've added the default implementation there as well.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated constructors in `linear_memory_resource` class to improve compiler compatibility
	- Modified default constructor to explicitly initialize parent member
	- Added template parameter adjustments to resolve MSVC 2019 compilation issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->