### PR TITLE
restore _GLIBCXX_DEBUG_BACKTRACE support in testing

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Pyarelal Knowles, MIT License
+# Copyright (c) 2024-2025 Pyarelal Knowles, MIT License
 
 cmake_minimum_required(VERSION 3.20)
 
@@ -21,8 +21,6 @@ target_link_libraries(
   gtest_main
   gmock_main)
 
-# TODO: presets?
-# https://stackoverflow.com/questions/45955272/modern-way-to-set-compiler-flags-in-cross-platform-cmake-project
 if(MSVC)
   target_compile_options(${PROJECT_NAME}_tests PRIVATE /W4 /WX)
   target_compile_definitions(${PROJECT_NAME}_tests PRIVATE WIN32_LEAN_AND_MEAN=1 NOMINMAX)
@@ -48,6 +46,20 @@ else()
       $<$<CONFIG:Debug>:-fsanitize=address,undefined,leak>)
     target_link_options(${PROJECT_NAME}_tests PRIVATE
       $<$<CONFIG:Debug>:-fsanitize=address,undefined,leak>)
+  endif()
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Ugly detection for a working _GLIBCXX_DEBUG_BACKTRACE config, but the
+    # feature itself is useful
+    include(glibcxx_debug_backtrace.cmake)
+    if(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+      target_compile_definitions(
+        ${PROJECT_NAME}_tests
+        PRIVATE $<$<CONFIG:Debug>:_GLIBCXX_DEBUG_BACKTRACE>)
+      target_link_libraries(${PROJECT_NAME}_tests
+                            $<$<CONFIG:Debug>:${GLIBCXX_DEBUG_BACKTRACE_LIBRARY}>)
+      target_compile_features(${PROJECT_NAME}_tests
+                              PRIVATE ${GLIBCXX_DEBUG_BACKTRACE_CXX_FEATURE})
+    endif()
   endif()
 endif()
 

--- a/test/glibcxx_debug_backtrace.cmake
+++ b/test/glibcxx_debug_backtrace.cmake
@@ -1,0 +1,73 @@
+# Copyright (c) 2025 Pyarelal Knowles, MIT License
+
+if(NOT DEFINED GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  set(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED false)
+endif()
+
+# Try default build with no extra libraries
+if(NOT GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  try_compile(
+    DEBUG_BACKTRACE_JUSTWORKS SOURCE_FROM_CONTENT
+    stdc++_libbacktrace_test.cpp
+    "#include <vector>\nint main() { std::vector<int> v{0}; return v[0]; }"
+    COMPILE_DEFINITIONS -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE)
+  if(DEBUG_BACKTRACE_JUSTWORKS)
+    set(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED true)
+    set(GLIBCXX_DEBUG_BACKTRACE_LIBRARY)
+    set(GLIBCXX_DEBUG_BACKTRACE_CXX_FEATURE)
+  endif()
+endif()
+
+# Try C++23 with no extra libraries
+if(NOT GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  try_compile(
+    DEBUG_BACKTRACE_NEEDCXX23 SOURCE_FROM_CONTENT
+    stdc++_libbacktrace_test.cpp
+    "#include <vector>\nint main() { std::vector<int> v{0}; return v[0]; }"
+    COMPILE_DEFINITIONS -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE
+                        CXX_STANDARD 23 CXX_STANDARD_REQUIRED true)
+  if(DEBUG_BACKTRACE_NEEDCXX23)
+    set(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED true)
+    set(GLIBCXX_DEBUG_BACKTRACE_LIBRARY)
+    set(GLIBCXX_DEBUG_BACKTRACE_CXX_FEATURE cxx_std_23)
+  endif()
+endif()
+
+# Try with libstdc++exp
+if(NOT GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  try_compile(
+    DEBUG_BACKTRACE_NEEDSTDEXP SOURCE_FROM_CONTENT
+    stdc++_libbacktrace_test.cpp
+    "#include <vector>\nint main() { std::vector<int> v{0}; return v[0]; }"
+    COMPILE_DEFINITIONS -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE CXX_STANDARD
+                        20 CXX_STANDARD_REQUIRED true
+    LINK_LIBRARIES stdc++exp)
+  if(DEBUG_BACKTRACE_NEEDSTDEXP)
+    set(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED true)
+    set(GLIBCXX_DEBUG_BACKTRACE_LIBRARY stdc++exp)
+    set(GLIBCXX_DEBUG_BACKTRACE_CXX_FEATURE)
+  endif()
+endif()
+
+# Try with libstdc++_libbacktrace
+if(NOT GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  try_compile(
+    DEBUG_BACKTRACE_NEEDLIBBACKTRACE SOURCE_FROM_CONTENT
+    stdc++_libbacktrace_test.cpp
+    "#include <vector>\nint main() { std::vector<int> v{0}; return v[0]; }"
+    COMPILE_DEFINITIONS -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE CXX_STANDARD
+                        20 CXX_STANDARD_REQUIRED true
+    LINK_LIBRARIES stdc++_libbacktrace)
+  if(DEBUG_BACKTRACE_NEEDLIBBACKTRACE)
+    set(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED true)
+    set(GLIBCXX_DEBUG_BACKTRACE_LIBRARY stdc++_libbacktrace)
+    set(GLIBCXX_DEBUG_BACKTRACE_CXX_FEATURE)
+  endif()
+endif()
+
+# Issue a warning if none of the above worked
+if(NOT GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  message(
+    WARNING "No working try_compile configs with _GLIBCXX_DEBUG_BACKTRACE found"
+  )
+endif()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Improved debugging support for GNU-based builds. The update now automatically detects available debug backtrace capabilities during compilation, offering more detailed error diagnostics when supported by your system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->