### PR TITLE
update align to avoid signed cast and clang warning

### DIFF
--- a/include/decodeless/allocator.hpp
+++ b/include/decodeless/allocator.hpp
@@ -133,8 +133,8 @@ public:
     }
 
     [[nodiscard]] constexpr void* allocate(std::size_t bytes, std::size_t align) {
-        // Align
-        uintptr_t result = m_next + ((-static_cast<ptrdiff_t>(m_next)) & (align - 1));
+        // Align, assumes 'align' is a power of two
+        uintptr_t result = (m_next + align - 1) & ~(align - 1);
 
         // Allocate
         uintptr_t newNext = result + bytes;


### PR DESCRIPTION
This does change the compiled result for all of gcc, clang, msvc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal memory alignment calculation while maintaining full compatibility with the existing public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->